### PR TITLE
Mise à jour du bilan par région

### DIFF
--- a/hydro-quebec/README.md
+++ b/hydro-quebec/README.md
@@ -20,6 +20,12 @@ Les données des sources d'électricité d'Hydro-Québec sont disponibles [https
 
 ### Info-panne
 
+#### Bilan des pannes par région
+
+Il est possible de créé des capteurs qui indique le nombre de panne en cours pour une région donnée. Un fichier de configuration est disponible ici [hydro-quebec/home-assistant/packages/hydro_quebec_pannes.yaml](hydro-quebec/home-assistant/packages/hydro_quebec_pannes.yaml)
+
+#### État des pannes pour un lieu spécifique
+
 L'info-panne d'Hydro-Québec est disponible à l'adresse suivante ``https://services-bs.solutions.hydroquebec.com/pan/web/api/v1/lieux-conso/etats/##LOCATION##``
 Les détails de la configuration sont disponible ici : [Configuration_info-panne](configuration_info-panne.md)
 

--- a/hydro-quebec/home-assistant/packages/hydro_quebec_pannes.yaml
+++ b/hydro-quebec/home-assistant/packages/hydro_quebec_pannes.yaml
@@ -1,48 +1,42 @@
-scrape:
-  - resource: https://pannes.hydroquebec.com/pannes/bilan-interruptions-service/
-    scan_interval: 600
+# Une liste en règle générale les "id" correspondent à ceux disponibles ici: https://www.quebec.ca/gouvernement/portrait-quebec/repertoire-municipalites
+# L'id "HQ" correspond à l'ensemble des clients Hydro-Québec
+# La liste complète des ID spécifique à HQ est aussi disponible ici: https://infopannes.solutions.hydroquebec.com/assets/data/bilan-par-region.json
+
+rest:
+  - resource: https://services-bs.solutions.hydroquebec.com/pan/web/api/v1/bis
     sensor:
       - name: "Hydro-Québec Interruptions - Québec"
-        unique_id: hydro-quebec-pannes-qc
+        unique_id: hydro-quebec-pannes-hq
         icon: mdi:transmission-tower-off
-        select: td.main-value
-        attribute: "data-value"
-        value_template: '{{ value | regex_replace("^[^0-9]","") | int }}'
-      - name: "Hydro-Québec Clients privés d'électricité - Québec"
+        unit_of_measurement: "clients"
+        value_template: |-
+          {% set region = value_json | selectattr('id', 'equalto', 'HQ') | list %}
+          {% if region %}
+            {{ region[0].nbClientInterrompu }}
+          {% else %}
+            0
+          {% endif %}
+        json_attributes_path: "$[?(@.id=='HQ')]"
+        json_attributes:
+          - "id"
+          - "nbClientRaccorde"
+          - "nbClientInterrompu" 
+          - "nbPanne"
+      
+      - name: "Hydro-Québec Interruptions - Laurentides"
+        unique_id: hydro-quebec-pannes-15
         icon: mdi:transmission-tower-off
-        unique_id: hydro-quebec-pannes-clients-qc
-        select: .standard > tfoot:nth-child(4) > tr:nth-child(1) > td:nth-child(3)
-        attribute: "data-value"
-        value_template: '{{ value | regex_replace("^1|[^0-9]","") | int }}'
-
-
-  # Configuration avancée!!
-  # Vous devez aller chercher le CSS selector pour le tableau de la région et remplacer le 'select', le URL de 'resource'
-  # et les autres valeurs pour correspondre à votre emplacement
-  # - resource: https://pannes.hydroquebec.com/pannes/bilan-interruptions-service/laurentides.html
-  #   scan_interval: 600
-  #   sensor:
-  #     - name: "Hydro-Québec Interruptions - Pays-d'en-haut"
-  #       unique_id: hydro-quebec-pannes-pdh
-  #       icon: mdi:transmission-tower-off
-  #       select: .standard > tbody:nth-child(2) > tr:nth-child(7) > td:nth-child(2)
-  #       attribute: "data-value"
-  #       value_template: '{{ value | regex_replace("^[^0-9]","") | int}}'
-  #     - name: "Hydro-Québec Clients privés d'électricité - Pays-d'en-haut"
-  #       unique_id: hydro-quebec-pannes-clients-pdh
-  #       icon: mdi:transmission-tower-off
-  #       select: .standard > tbody:nth-child(2) > tr:nth-child(7) > td:nth-child(3)
-  #       attribute: "data-value"
-  #       value_template: '{{ value | regex_replace("^1|[^0-9]","") | int}}'
-  #     - name: "Hydro-Québec Interruptions - Laurentides"
-  #       unique_id: hydro-quebec-pannes-laurentides
-  #       icon: mdi:transmission-tower-off
-  #       select: td.main-value
-  #       attribute: "data-value"
-  #       value_template: '{{ value | regex_replace("^[^0-9]","") | int}}'
-  #     - name: "Hydro-Québec Clients privés d'électricité - Laurentides"
-  #       unique_id: hydro-quebec-pannes-clients-laurentides
-  #       icon: mdi:transmission-tower-off
-  #       select: .standard > tfoot:nth-child(3) > tr:nth-child(1) > td:nth-child(3)
-  #       attribute: "data-value"
-  #       value_template: '{{ value | regex_replace("^1|[^0-9]","") | int}}'
+        unit_of_measurement: "clients"
+        value_template: |-
+          {% set region = value_json | selectattr('id', 'equalto', '15') | list %}
+          {% if region %}
+            {{ region[0].nbClientInterrompu }}
+          {% else %}
+            0
+          {% endif %}
+        json_attributes_path: "$[?(@.id=='15')]"
+        json_attributes:
+          - "id"
+          - "nbClientRaccorde"
+          - "nbClientInterrompu" 
+          - "nbPanne"


### PR DESCRIPTION
Les anciennes configuration "scrape" pour obtenir le bilan des pannes HQ ne fonctionnent plus depuis un certain temps.

Ce PR retire le mode scrape et le remplace par des sensors REST.